### PR TITLE
ci: fix nix build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,6 +81,9 @@ jobs:
         with:
           PATTERNS: |
             **/**.py
+            go.mod
+            go.sum
+            gomod2nix.toml
       - name: run gomod2nix
         run: |
           nix run -f ./nix gomod2nix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
             go.mod
             go.sum
             tests/integration_tests/**
+            *.nix
       - name: Run integration tests
         run: make run-integration-tests
         if: env.GIT_DIFF

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ in
 buildGoApplication rec {
   inherit pname version tags ldflags;
   src = lib.sourceByRegex ./. [
-    "^(x|app|cmd|client|server|crypto|rpc|types|encoding|ethereum|indexer|testutil|version|go.mod|go.sum|gomod2nix.toml)($|/.*)"
+    "^(x|app|cmd|client|server|crypto|rpc|types|encoding|ethereum|indexer|testutil|version|go.mod|go.sum|gomod2nix.toml|store)($|/.*)"
     "^tests(/.*[.]go)?$"
   ];
   modules = ./gomod2nix.toml;

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -200,8 +200,9 @@ schema = 3
     version = "v1.0.0"
     hash = "sha256-k1DYvCqO3BKNcGEve/nMW0RxzMkK2tGfXbUbycqcVSo="
   [mod."github.com/ethereum/go-ethereum"]
-    version = "v1.10.26"
-    hash = "sha256-gkMEwJ4rOgn12amD4QpZ4th/10uyTTeoFmpseuKDQPs="
+    version = "v1.10.26-spc"
+    hash = "sha256-Xzp0RdXEo7a1IaZ2feEEGQnSdtL2xjLm8Ldhb6+oiHU="
+    replaced = "github.com/zeta-chain/go-ethereum"
   [mod."github.com/felixge/httpsnoop"]
     version = "v1.0.2"
     hash = "sha256-hj6FZQ1fDAV+1wGIViAt8XaAkWZ1I5vJzgjIJa7XRBA="


### PR DESCRIPTION
`store` directory was missing from sources and `gomod2nix` needed to be run.

Also update the diff patterns so CI isn't missed in needed cases.

Last known good commit: https://github.com/zeta-chain/ethermint/commit/61d040058c9400f25e560a716a70e7644294d77a

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded build configuration to include additional source files from the store directory, enhancing the application's resource scope.
	- Updated the Ethereum Go client module to a new version, improving dependency management.
	- Enhanced linting coverage by including Go module files for better code quality.

- **Bug Fixes**
	- Corrected dependency resolution by specifying a replacement for the Ethereum module, ensuring better compatibility and stability.
	
- **Chores**
	- Modified GitHub Actions workflows to monitor additional file types for linting and testing, improving integration processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->