### PR TITLE
feat: set precompiles after keeper creation

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -412,7 +412,7 @@ func (k Keeper) AddTransientGasUsed(ctx sdk.Context, gasUsed uint64) (uint64, er
 }
 
 // ----------------------------------------------------------------------------
-// Stateful Precompiled Contracts sectopn
+// Stateful Precompiled Contracts section
 // ----------------------------------------------------------------------------
 
 func (k *Keeper) WithStatefulPrecompiledContracts(contracts []CustomContractFn) {

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -410,3 +410,11 @@ func (k Keeper) AddTransientGasUsed(ctx sdk.Context, gasUsed uint64) (uint64, er
 	k.SetTransientGasUsed(ctx, result)
 	return result, nil
 }
+
+// ----------------------------------------------------------------------------
+// Stateful Precompiled Contracts sectopn
+// ----------------------------------------------------------------------------
+
+func (k *Keeper) WithStatefulPrecompiledContracts(contracts []CustomContractFn) {
+	k.customContractFns = contracts
+}


### PR DESCRIPTION
## Description

When creating an EVM Keeper with precompiles from the core Zeta node, it can be the case there are circular dependencies, such as:
- Create evmkeeper with precompiles; one precompile requires the fungible keeper properly initialized.
- Create the fungible keeper after evmkeeper, as fungible requires evm.

To solve this a function to set the precompiles is exposed:
- Create EVM Keeper.
- Create Fungible Keeper.
- Set the precompiles with the updated dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new method to enhance contract management capabilities, allowing for the dynamic configuration of stateful precompiled contracts within the app's EVM context.

- **Bug Fixes**
	- No bug fixes included in this release.

- **Documentation**
	- Updated documentation to reflect the new method and its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->