### PR TITLE
chore: move NewTracer to keeper

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -286,7 +286,7 @@ func (k *Keeper) PostTxProcessing(ctx sdk.Context, msg core.Message, receipt *et
 
 // Tracer return a default vm.Tracer based on current keeper state
 func (k Keeper) Tracer(ctx sdk.Context, msg core.Message, ethCfg *params.ChainConfig) vm.EVMLogger {
-	return types.NewTracer(k.tracer, msg, ethCfg, ctx.BlockHeight())
+	return NewTracer(k.tracer, msg, ethCfg, ctx.BlockHeight())
 }
 
 // GetAccountWithoutBalance load nonce and codehash without balance,

--- a/x/evm/keeper/tracer.go
+++ b/x/evm/keeper/tracer.go
@@ -1,0 +1,50 @@
+// Copyright 2021 Evmos Foundation
+// This file is part of Evmos' Ethermint library.
+//
+// The Ethermint library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Ethermint library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Ethermint library. If not, see https://github.com/zeta-chain/ethermint/blob/main/LICENSE
+package keeper
+
+import (
+	"math/big"
+	"os"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/zeta-chain/ethermint/x/evm/types"
+)
+
+// NewTracer creates a new Logger tracer to collect execution traces from an
+// EVM transaction.
+func NewTracer(tracer string, msg core.Message, cfg *params.ChainConfig, height int64) vm.EVMLogger {
+	// TODO: enable additional log configuration
+	logCfg := &logger.Config{
+		Debug: true,
+	}
+
+	switch tracer {
+	case types.TracerAccessList:
+		preCompiles := vm.DefaultActivePrecompiles(cfg.Rules(big.NewInt(height), cfg.MergeNetsplitBlock != nil))
+		return logger.NewAccessListTracer(msg.AccessList(), msg.From(), *msg.To(), preCompiles)
+	case types.TracerJSON:
+		return logger.NewJSONLogger(logCfg, os.Stderr)
+	case types.TracerMarkdown:
+		return logger.NewMarkdownLogger(logCfg, os.Stdout) // TODO: Stderr ?
+	case types.TracerStruct:
+		return logger.NewStructLogger(logCfg)
+	default:
+		return types.NewNoOpTracer()
+	}
+}

--- a/x/evm/types/tracer.go
+++ b/x/evm/types/tracer.go
@@ -17,15 +17,10 @@ package types
 
 import (
 	"math/big"
-	"os"
 	"time"
 
-	"github.com/ethereum/go-ethereum/eth/tracers/logger"
-
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 const (
@@ -34,29 +29,6 @@ const (
 	TracerStruct     = "struct"
 	TracerMarkdown   = "markdown"
 )
-
-// NewTracer creates a new Logger tracer to collect execution traces from an
-// EVM transaction.
-func NewTracer(tracer string, msg core.Message, cfg *params.ChainConfig, height int64) vm.EVMLogger {
-	// TODO: enable additional log configuration
-	logCfg := &logger.Config{
-		Debug: true,
-	}
-
-	switch tracer {
-	case TracerAccessList:
-		preCompiles := vm.DefaultActivePrecompiles(cfg.Rules(big.NewInt(height), cfg.MergeNetsplitBlock != nil))
-		return logger.NewAccessListTracer(msg.AccessList(), msg.From(), *msg.To(), preCompiles)
-	case TracerJSON:
-		return logger.NewJSONLogger(logCfg, os.Stderr)
-	case TracerMarkdown:
-		return logger.NewMarkdownLogger(logCfg, os.Stdout) // TODO: Stderr ?
-	case TracerStruct:
-		return logger.NewStructLogger(logCfg)
-	default:
-		return NewNoOpTracer()
-	}
-}
 
 // TxTraceResult is the result of a single transaction trace during a block trace.
 type TxTraceResult struct {


### PR DESCRIPTION
Avoid references to `vm.DefaultActivePrecompiles` in types to ensure that types can be imported without requiring `replace github.com/ethereum/go-ethereum => github.com/zeta-chain/go-ethereum v1.10.26-spc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `NewTracer` function for enhanced logging capabilities in the Ethermint library, allowing for various formats of EVM transaction tracing.
  
- **Bug Fixes**
	- Updated the `Tracer` method to call `NewTracer` directly, ensuring consistent functionality without altering parameters or return types.

- **Refactor**
	- Removed the previous `NewTracer` function from the `types` package, streamlining the codebase by consolidating tracer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->